### PR TITLE
開発者向け情報の相対リンクが壊れていたので直した

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,4 +19,4 @@ GitHub Pages が付随していたりして簡単には移動できないやつ
 
 ## 開発者向け情報
 
-[開発者向け情報](developers/index.md)
+[開発者向け情報](https://github.com/cetkaik/.github/blob/main/profile/developers/index.md)


### PR DESCRIPTION
[organization の top page](https://github.com/cetkaik)から開発者向け情報に相対リンクで飛べなかったので、絶対リンクに修正